### PR TITLE
Normalize changelog date time zone to local

### DIFF
--- a/tasks/assets/README.tmpl.md
+++ b/tasks/assets/README.tmpl.md
@@ -34,8 +34,12 @@ _Run this task with the `grunt {%= name %}` command._
 ## Release History
 {% if (changelog) {
   _.each(changelog, function(details, version) {
+    var date = details.date;
+    if (date instanceof Date) {
+      date = grunt.template.date(new Date(date.getTime() + date.getTimezoneOffset() * 60000), 'yyyy-mm-dd');
+    }
     print('\n * ' + [
-      grunt.template.date(details.date, 'yyyy-mm-dd'),
+      date,
       version,
       details.changes.join(' '),
     ].join('\u2003\u2003\u2003'));


### PR DESCRIPTION
The changelog dates in the readme are currently off by -1 for every grunt-contrib-\* task because the dates pulled in from the YAML files are recognized as dates and processed through the JavaScript `Date()` object. Since the dates in the changelogs do not specify a timezone they are assumed to be 00:00:00 UTC time.

When they are converted to local time those of us who live on the bad side of the date line will see the date one day off.

This patch fixes this issue by normalizing the Date pulled from the changelog file to local time.

Resolves issue #7.
