### PR TITLE
build travis urls w/ repository url

### DIFF
--- a/tasks/assets/README.tmpl.md
+++ b/tasks/assets/README.tmpl.md
@@ -1,4 +1,4 @@
-# {%= name %}{% if (travis) { %} [![Build Status](https://secure.travis-ci.org/gruntjs/{%= name %}.png?branch=master)](http://travis-ci.org/gruntjs/{%= name %}){% } %}
+# {%= name %}{% if (travis) { %} [![Build Status]({%= travis %}.png?branch=master)]({%= travis %}){% } %}
 
 > {%= description %}
 

--- a/tasks/build-contrib.js
+++ b/tasks/build-contrib.js
@@ -21,6 +21,9 @@ module.exports = function(grunt) {
     meta.changelog = grunt.file.readYAML('CHANGELOG');
 
     meta.travis = grunt.file.exists('.travis.yml');
+    if (meta.travis) {
+      meta.travis = meta.repository.url.replace(/.*:\/\/github.com\/(.*)\.git/, 'https://travis-ci.org/$1');
+    }
 
     var authors = grunt.file.read('AUTHORS');
     meta.authors = authors.split('\n').map(function(author) {


### PR DESCRIPTION
As mentioned in #9.
I've also updated both image and link URLs as Travis seems to have [unified](http://about.travis-ci.org/docs/user/status-images/) them.
