### PR TITLE
Add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # grunt-contrib-internal v0.4.9
+[![NPM version](https://badge.fury.io/js/grunt-contrib-internal.svg)](http://badge.fury.io/js/grunt-contrib-internal) [![Dependency Status](https://david-dm.org/gruntjs/grunt-contrib-internal.svg)](https://david-dm.org/gruntjs/grunt-contrib-internal) [![devDependency Status](https://david-dm.org/gruntjs/grunt-contrib-internal/dev-status.svg)](https://david-dm.org/gruntjs/grunt-contrib-internal#info=devDependencies) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com/)
 
 > Internal tasks for managing the grunt-contrib project.
 
@@ -42,4 +43,4 @@ _This plugin is used internally by grunt-contrib plugins, and shouldn't be used 
 
 Task submitted by ["Cowboy" Ben Alman](http://benalman.com/)
 
-*This file was generated on Tue Apr 08 2014 16:03:00.*
+*This file was generated on Tue Apr 08 2014 17:58:16.*

--- a/tasks/assets/README.tmpl.md
+++ b/tasks/assets/README.tmpl.md
@@ -1,4 +1,5 @@
-# {%= name %} v{%= version %}{% if (travis) { %} [![Build Status: Linux]({%= travis %}.png?branch=master)]({%= travis %}){% } %}{% if (appveyor) { %} <a href="https://ci.appveyor.com/project/gruntjs/{%= name %}"><img src="{%= appveyor %}" alt="Build Status: Windows" height="18" /></a>{% } %}
+# {%= name %} v{%= version %}
+[![NPM version](https://badge.fury.io/js/{%= name %}.svg)](http://badge.fury.io/js/{%= name %}){% if (travis) { %} [![Build Status]({%= travis %}.svg?branch=master)]({%= travis %}){% } %}{% if (appveyor) { %} [![Build Status: Windows]({%= appveyor %})](https://ci.appveyor.com/project/gruntjs/{%= name %}){% } %} [![Dependency Status](https://david-dm.org/gruntjs/grunt-contrib-internal.svg)](https://david-dm.org/gruntjs/grunt-contrib-internal) [![devDependency Status](https://david-dm.org/gruntjs/grunt-contrib-internal/dev-status.svg)](https://david-dm.org/gruntjs/grunt-contrib-internal#info=devDependencies) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com/)
 
 > {%= description %}
 


### PR DESCRIPTION
I figured adding the following badges to grunt-contrib projects would be useful: (example using grunt-contrib-stylus)

---
# grunt-contrib-stylus v0.13.2

[![NPM version](https://badge.fury.io/js/grunt-contrib-stylus.svg)](http://badge.fury.io/js/grunt-contrib-stylus) [![Build Status](https://travis-ci.org/gruntjs/grunt-contrib-stylus.svg?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-stylus) [![Dependency Status](https://david-dm.org/gruntjs/grunt-contrib-stylus.svg)](https://david-dm.org/gruntjs/grunt-contrib-stylus) [![devDependency Status](https://david-dm.org/gruntjs/grunt-contrib-stylus/dev-status.svg)](https://david-dm.org/gruntjs/grunt-contrib-stylus#info=devDependencies) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com/)

> Compile Stylus files to CSS.

---

If theres any that you think do not belong, let me know and I'll take it out. Also, I can go through all the contrib projects to update the READMEs, and try to update any out of date dependencies so you can get them all up to date.

---

**Changes:**
- Added npm version badge
- Updated travis badge to use svg version
- Added David DM badges
- Added Built with Grunt badge

---

If you need anything else in this PR, please let me know. Thanks
