### PR TITLE
Add a "test" target.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,5 +31,6 @@ module.exports = function(grunt) {
 
   // By default, lint task.
   grunt.registerTask('default', ['jshint', 'build-contrib']);
+  grunt.registerTask('test', ['default']);
 
 };


### PR DESCRIPTION
It's an alias for the default target.

Fixes `npm test`.
