### PR TITLE
Tweak appveyor.yml.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,34 +1,44 @@
-# Fix line endings on Windows
-init:
-  - git config --global core.autocrlf true
+# http://www.appveyor.com/docs/appveyor-yml
+
+clone_depth: 10
+
+version: "{build}"
+
 # What combinations to test
 environment:
   matrix:
     - nodejs_version: "0.10"
+      platform: x86
     - nodejs_version: "0.12"
+      platform: x86
     - nodejs_version: "4"
+      platform: x64
+    - nodejs_version: "4"
+      platform: x86
     - nodejs_version: "5"
-platform:
-  - x86
-  - x64
+      platform: x86
+
 install:
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:nodejs_version $env:platform
   - ps: >-
       if ($env:nodejs_version -eq "0.10") {
         npm -g install npm@3
         $env:PATH="$env:APPDATA\npm;$env:PATH"
       }
   - npm install
+
 test_script:
-  # Output useful info for debugging.
+  # Output useful info for debugging
   - node --version && npm --version
   # We test multiple Windows shells because of prior stdout buffering issues
   # filed against Grunt. https://github.com/joyent/node/issues/3584
   - ps: "npm test # PowerShell" # Pass comment to PS for easier debugging
   - cmd: npm test
+
 build: off
-clone_depth: 10
+
 matrix:
   fast_finish: true
+
 cache:
   - node_modules -> package.json


### PR DESCRIPTION
* Test x64 only for node.js 4
* Remove autocrlf

You can see the output https://ci.appveyor.com/project/gruntjs/grunt-contrib-concat/build/44

/CC @shama