### PR TITLE
Remove the explicit install of npm@2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ node_js:
   - "4"
   - "5"
   - "iojs"
-before_install:
-  - if [ "$TRAVIS_NODE_VERSION" = "0.10" ]; then npm install -g npm@2; fi
 matrix:
   fast_finish: true
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,11 +20,6 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - ps: >-
-      if ($env:nodejs_version -eq "0.10") {
-        npm -g install npm@2
-        $env:PATH="$env:APPDATA\npm;$env:PATH"
-      }
   - npm install
 
 test_script:


### PR DESCRIPTION
Node.js [0.10.44](https://nodejs.org/en/blog/release/v0.10.44/) already includes npm@2.

/CC @shama @vladikoff 

We should wait until AppVeyor updates to 0.10.44 so that this works. /CC @FeodorFitsner
