### PR TITLE
Update Node.js versions CI are using.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,9 @@ sudo: false
 language: node_js
 
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
-  - "5"
   - "6"
-  - "iojs"
+  - "7"
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,17 +5,13 @@ version: "{build}"
 # What combinations to test
 environment:
   matrix:
-    - nodejs_version: "0.10"
-      platform: x86
-    - nodejs_version: "0.12"
-      platform: x86
     - nodejs_version: "4"
       platform: x64
     - nodejs_version: "4"
       platform: x86
-    - nodejs_version: "5"
-      platform: x86
     - nodejs_version: "6"
+      platform: x86
+    - nodejs_version: "7"
       platform: x86
 
 install:


### PR DESCRIPTION
Remove 0.10, 0.12 and 5, and add 7.

/CC @vladikoff @shama: Do **NOT** merge yet.

We should discuss how we are going to proceed. My suggestion is to support LTS releases and the latest one, which is what I did in this PR.