### PR TITLE
v2.0.0.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v2.0.0:
+  date: 2017-11-26
+  changes:
+    - Update major version since the node.js 0.10 removal is a breaking change.
 v1.4.2:
   date: 2017-11-23
   changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-contrib-internal",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-internal",
   "description": "Internal tasks for managing the grunt-contrib projects",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "author": {
     "name": "Grunt Team",
     "url": "http://gruntjs.com/"


### PR DESCRIPTION
@vladikoff: you should have bumped the major version when you dropped 0.10 support.

After we merge this, we need a new release and remove the old ones (1.4.0, 1.4.1 and 1.4.2) from npm and GitHub.