### PR TITLE
Update .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,7 +3,7 @@
   "curly": true,
   "eqeqeq": true,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "immed": true,
   "latedef": true,
   "newcap": true,


### PR DESCRIPTION
Use `esversion: 6` instead of the deprecated `esnext` option.